### PR TITLE
Fix for linux erase/write issue.

### DIFF
--- a/commandline/library/micronucleus_lib.c
+++ b/commandline/library/micronucleus_lib.c
@@ -89,7 +89,15 @@ int micronucleus_eraseFlash(micronucleus* deviceHandle, micronucleus_callback pr
     i += 0.01;
   }
   
-  if (res == -5)
+  /* Under Linux, the erase process is often aborted with errors such as:
+   usbfs: USBDEVFS_CONTROL failed cmd micronucleus rqt 192 rq 2 len 0 ret -84
+   This seems to be because the erase is taking long enough that the device
+   is disconnecting and reconnecting.  Under Windows, micronucleus can see this
+   and automatically reconnects prior to uploading the program.  To get the
+   the same functionality, we must flag this state (the "-84" error result) by
+   converting the return to -2 for the upper layer.
+  */
+  if (res == -5 || res == -84)
     return -2;
   if (res != 0)
     return -1;


### PR DESCRIPTION
Erasing the memory ...
  erasing: 66% complete
  Error erasing: -84>> Abort mission! error has occured ...
  Please unplug the device and restart the program.

Whereas Windows can recover from this condition with

  Eep! Connection to device lost during erase! Not to worry
  This happens on some computers - reconnecting...

the Linux version could not correctly interpret the -84 error code returned by the USBDEVFS_CONTROL call.

This modification fixes this, re-interpreting the -84 code to -2 and allowing the program to reconnect and successfully upload the firmware.

Output of program when uploading a small sketch (hex file) is now:

Binary sketch size: 756 bytes (of a 6,010 byte maximum)
Running Digispark Uploader...
Plug in device now...

> Please plug in the device ... 
> Press CTRL+C to terminate the program.
> Device is found!
> connecting: 40% complete
> Available space for user application: 6010 bytes
> Suggested sleep time between sending pages: 8ms
> Whole page count: 94
> Erase function sleep duration: 752ms
> parsing: 60% complete
> Erasing the memory ...
> erasing: 79% complete
> 
> > Eep! Connection to device lost during erase! Not to worry
> > This happens on some computers - reconnecting...
> > erasing: 80% complete
> > Starting to upload ...
> > writing: 100% complete
> > Micronucleus done. Thank you!

And the digispark acts as expected.
