### PR TITLE
Allow override of PROGRAMMER on make command line

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -26,7 +26,7 @@ LOCKOPT = -U lock:w:0x2f:m
 # - round that down to 94 - our new bootloader address is 94 * 64 = 6016, in hex = 1780
 BOOTLOADER_ADDRESS = 18C0
 
-PROGRAMMER = -c USBasp
+PROGRAMMER ?= -c USBasp
 # PROGRAMMER contains AVRDUDE options to address your programmer
 
 FUSEOPT_8 = -U hfuse:w:0xc0:m -U lfuse:w:0x9f:m

--- a/upgrade/Makefile
+++ b/upgrade/Makefile
@@ -21,7 +21,7 @@ LOCKOPT = -U lock:w:0x2f:m
 # app starts two pages in, so we can mess around with the first page for leet ISR hax
 APP_ADDRESS = 80
 
-PROGRAMMER = -c USBasp
+PROGRAMMER ?= -c USBasp
 # PROGRAMMER contains AVRDUDE options to address your programmer
 
 FUSEOPT_8 = -U hfuse:w:0xc0:m -U lfuse:w:0x9f:m


### PR DESCRIPTION
With this change, users of other programmers (e.g. the USBtiny) can specify the programmer on the command line.

For example:

``` sh
make PROGRAMMER='-c USBtiny' fuse flash disablereset
```
