### PR TITLE
Support OpenBSD

### DIFF
--- a/commandline/Makefile
+++ b/commandline/Makefile
@@ -20,6 +20,11 @@ else ifeq ($(shell uname), Darwin)
 	# USBLIBS += -framework IOKit
 	# Uncomment these to create a dual architecture binary:
 	# OSFLAG += -arch x86_64 -arch i386
+else ifeq ($(shell uname), OpenBSD)
+	USBFLAGS=$(shell libusb-config --cflags || libusb-legacy-config --cflags)
+	USBLIBS=$(shell libusb-config --libs || libusb-legacy-config --libs)
+	EXE_SUFFIX =
+	OSFLAG = -D OPENBSD
 else
 	USBFLAGS = -I C:\MinGW\include
 	USBLIBS = -L C:\MinGW\lib -lusb


### PR DESCRIPTION
I successfully compiled the micronucleus commandline on OpenBSD with this change and used it to push an hex to a digispark pro beta, using `micronucleus --run blink.hex`.
I don't know if thing need more testing but look like it's working.
