### PR TITLE
Fix osccalASM.S to work when connected to hub

### DIFF
--- a/firmware/osccalASM.S
+++ b/firmware/osccalASM.S
@@ -147,20 +147,20 @@ usbCOWaitLoop:
     sbic    USBIN, USBMINUS ;[2] 
     rjmp    usbCOWaitLoop   ;[3]
 
-	sbis    USBIN, USBPLUS	; ignore frame if data is present
-	rjmp    usbCOnotdata
+    sbis    USBIN, USBPLUS  ; ignore frame if data is present
+    rjmp    usbCOnotdata
 
 usbCOWaitNoData:
-	in		cnt16H, USBIN	; wait for SE0 state (both lines low)
-	andi	cnt16H, (1<<USBPLUS)|(1<<USBMINUS)
-	brne	usbCOWaitNoData
-	in		cnt16H, USBIN	; be sure SE0 state wasn't a glitch
-	andi	cnt16H, (1<<USBPLUS)|(1<<USBMINUS)
-	brne	usbCOWaitNoData
+    in      cnt16H, USBIN   ; wait for SE0 state (both lines low)
+    andi    cnt16H, (1<<USBPLUS)|(1<<USBMINUS)
+    brne    usbCOWaitNoData
+    in      cnt16H, USBIN   ; be sure SE0 state wasn't a glitch
+    andi    cnt16H, (1<<USBPLUS)|(1<<USBMINUS)
+    brne    usbCOWaitNoData
 usbCOWaitNoData2:
-    sbis    USBIN, USBMINUS	; wait for D- go to high
+    sbis    USBIN, USBMINUS ; wait for D- go to high
     rjmp    usbCOWaitNoData2
-	rjmp	usbCOLoopNoCal
+    rjmp    usbCOLoopNoCal
 
 usbCOnotdata:
 	sbrs	cnt16H, 7		;delay overflow?


### PR DESCRIPTION
A hub can broadcast USB packets intended for other devices to micronucleus just after the USB reset pulse, before osccalASM.S has had time to calibrate OSCCAL based on the 1kHz keepalive pulses. On one of my machines osccalASM.S was getting confused by these packets and thinking they were really closely spaced keepalive pulses, so coming up with a wildly wrong OSCCAL value and causing V-USB not to work. This change detects USB packets during this time and avoids using that 1mS interval for calibration.

cpldcpu has commented in email that this fix might not be sufficient as heavy hub activity just after reset could cause this new osccalASM.S to keep ignoring every USB frame (due to data packets) and never finish, with the host eventually starting to try to communicate with micronucleus and timing out.
