### PR TITLE
Remove redundant zeroing of SREG in init code

### DIFF
--- a/firmware/crt1.S
+++ b/firmware/crt1.S
@@ -95,7 +95,6 @@ __init:
 
 	.section .init2,"ax",@progbits
 	clr		R1
-	out		0x3f,r1
 	ldi		r28,lo8(__stack)
 	ldi		r29,hi8(__stack)
 	out		0x3d, r28


### PR DESCRIPTION
I believe that the line zeroing out SREG can safely be omitted, saving 2 bytes. The datasheet section 7.3.1 shows that all bits in SREG get an initial value of 0...

![image](https://cloud.githubusercontent.com/assets/5520281/5591362/03a42582-9125-11e4-85e9-80359c8dd077.png)

..and the datasheet section 11.1 shows that all registers are set to their initial values upon reset...

![image](https://cloud.githubusercontent.com/assets/5520281/5591363/4587eaf6-9125-11e4-8ee5-cc19affb276e.png)