### PR TITLE
added errorcode when reconnecting during erase

### DIFF
--- a/commandline/library/micronucleus_lib.c
+++ b/commandline/library/micronucleus_lib.c
@@ -147,12 +147,12 @@ int micronucleus_eraseFlash(micronucleus* deviceHandle, micronucleus_callback pr
    is disconnecting and reconnecting.  Under Windows, micronucleus can see this
    and automatically reconnects prior to uploading the program.  To get the
    the same functionality, we must flag this state (the "-84" error result) by
-   converting the return to -2 for the upper layer.
+   converting the return to -2 for the upper layer. (Note "-71" seems to be a similar error.)
 
    On Mac OS a common error is -34 = epipe, but adding it to this list causes:
    Assertion failed: (res >= 4), function micronucleus_connect, file library/micronucleus_lib.c, line 63.
   */
-  if (res == -5 || res == -34 || res == -84) {
+  if (res == -5 || res == -34 || res == -71 || res == -84) {
     if (res == -34) {
       usb_close(deviceHandle->device);
       deviceHandle->device = NULL;


### PR DESCRIPTION
On my machine under Ubuntu 16.04.03 (on an MSI B350 mainboard) when I try to upload the code then 9 times out of 10 I get an error during (after?) the erase with the following message in the syslog:
  usbfs: USBDEVFS_CONTROL failed cmd micronucleus rqt 64 rq 2 len 0 ret -71
With Windows 10 at the same stage I get the "Eep! Connection to device lost during erase! Not to worry" message and the upload continues successfully. It looks very similar to the "error -84" issue to me. Getting Linux to also try a reconnect solves the problem for me.

After some digging I found that -71 is EPROTO "Protocol error" and -84 is EILSEQ "Illegal byte sequence". On https://www.mjmwired.net/kernel/Documentation/usb/error-codes.txt I found that both codes can be cause by "no response packet received within the prescribed bus turn-around time" and "This is also one of several codes that different kinds of host controller use to indicate a transfer has failed because of device disconnect." So I guess it is essentially the same error.