### PR TITLE
Catch error -32 on erase

### DIFF
--- a/commandline/library/micronucleus_lib.c
+++ b/commandline/library/micronucleus_lib.c
@@ -159,7 +159,7 @@ int micronucleus_eraseFlash(micronucleus* deviceHandle, micronucleus_callback pr
    On Mac OS a common error is -34 = epipe, but adding it to this list causes:
    Assertion failed: (res >= 4), function micronucleus_connect, file library/micronucleus_lib.c, line 63.
   */
-  if (res == -5 || res == -34 || res == -71 || res == -84) {
+  if (res == -5 || res == -32 || res == -34 || res == -71 || res == -84) {
     if (res == -34) {
       usb_close(deviceHandle->device);
       deviceHandle->device = NULL;


### PR DESCRIPTION
Error -32 timeout is reported when erasing a device (attiny85 digispark) connected to an external USB 3.0 hub.
Tested and verified fixed with  an ORICO W9PH4-U3-V1 hub (Via-Labs VL812 controller chip)
I can now use this hub to flash, which has toggle switches!