### PR TITLE
Solution for issue micronucleus#111

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -216,11 +216,11 @@ static void initHardware (void)
   // Disable watchdog and set timeout to maximum in case the WDT is fused on 
 #ifdef CCP
   // New ATtinies841/441 use a different unlock sequence and renamed registers
-  MCUSR=0;    
+  MCUSR = ~_BV(WDRF);    
   CCP = 0xD8; 
   WDTCSR = 1<<WDP2 | 1<<WDP1 | 1<<WDP0; 
 #elif defined(WDTCR)
-  MCUSR=0;    
+  MCUSR = ~_BV(WDRF);   
   WDTCR = 1<<WDCE | 1<<WDE;
   WDTCR = 1<<WDP2 | 1<<WDP1 | 1<<WDP0;
 #else

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -390,7 +390,7 @@ int main(void) {
 
     LED_EXIT();
     
-    initHardware();  /* Disconnect micronucleus */    
+    usbDeviceDisconnect(); /* Disconnect micronucleus */   
     
     USB_INTR_ENABLE = 0;
     USB_INTR_CFG = 0;       /* also reset config bits */


### PR DESCRIPTION
This keeps all MCUSR flags except the WDRF, which we want to reset here.
I tested it carefully. After compiling the code size was only increased by 2.