### PR TITLE
firmware: improve compactness

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -1,4 +1,4 @@
-Micronucleus V2.04
+Micronucleus V2.05
 ==================
 
 Micronucleus is a bootloader designed for AVR ATtiny microcontrollers with a minimal usb interface, cross platform libusb-based program upload tool, and a strong emphasis on bootloader compactness. To the authors knowledge this is, by far, the smallest USB bootloader for AVR ATtiny
@@ -44,14 +44,14 @@ To allow maximum flexibility, micronucleus supports a configuration system. To c
 
 Currently, the following configurations are included and tested. Please check the subfolders /firmware/configurations/ for details. Hex files can be found in /releases.
 
-t84_default     -   ATtiny84A default configuration     -   1534 bytes
-t841_default    -   ATtiny841 default configuration     -   1586 bytes
-t45_default     -   ATtiny85  default configuration     -   1588 bytes
-t85_default     -   ATtiny85  default configuration     -   1588 bytes
-t85_aggressive  -   ATtiny85  smaller size - critical   -   1418 bytes
-t167_default    -   ATtiny167 default (uses xtal)       -   1412 bytes
-Nanite841       -   Nanite841 firmware                  -   1610 bytes
-m328p_extclock  -   ATMega328p external clock           -   1434 bytes
+t84_default     -   ATtiny84A default configuration     -   15?? bytes
+t841_default    -   ATtiny841 default configuration     -   15?? bytes
+t45_default     -   ATtiny85  default configuration     -   15?? bytes
+t85_default     -   ATtiny85  default configuration     -   15?? bytes
+t85_aggressive  -   ATtiny85  smaller size - critical   -   14?? bytes
+t167_default    -   ATtiny167 default (uses xtal)       -   14?? bytes
+Nanite841       -   Nanite841 firmware                  -   16?? bytes
+m328p_extclock  -   ATMega328p external clock           -   14?? bytes
 
 Please note that the configuration "t84_aggressive" may be instable unders certain circumstances. Please revert to "t85_default" if downloading of user programs fails.
 
@@ -132,11 +132,14 @@ Changes
       This will let micronucleus timeout also when traffic from other USB devices
       is present on the bus.
 
+
+• v2.05 xxxxx 2019
+        
 Credits
 =======
 
 Firmware:
- • Micronucleus V2.04            (c) 2019 Current maintainers: @cpldcpu, @AHorneffer
+ • Micronucleus V2.05            (c) 2019 Current maintainers: @cpldcpu, @AHorneffer
  • Micronucleus V2.0x            (c) 2016 Tim Bo"scke - cpldcpu@gmail.com
                                  (c) 2014 Shay Green
  • Original Micronucleus         (c) 2012 Jenna Fox


### PR DESCRIPTION
I had a look at disassembled v2.04 t85_default. I'd like to discuss some changes in firmware code in order to help improve compactness (without changing algorithm).

- there are 9 unused registers (r8..r15, r23) and 37 SRAM accesses by lds/sts commands to access variables; by placing the (global) variables of usbdrv.c into registers (as it is done with 'currentAddress' and 'idlePolls' in main.c) would save 74 bytes, e.g.
   uchar       usbDeviceAddr;
change to 
   register uchar usbDeviceAddr asm("r8");

- there are 20 SRAM accesses by lds/sts commands to read or write data in the transmit/receive buffer; accessing them with a base-pointer + displacement would save 36 bytes

- the functions 'boot_page_erase', 'boot_page_write' and 'boot_page_fill' as defined in 'boot.h' waste 2 bytes each by accessing SPMCSR as a RAM-location (sts command) instead of a port register (out command) (6 bytes)

- 'usbCrc16Append' is very short; as it is called only once, it could be placed inline  (4 bytes)

- as long as 'usbCrc16' is called only once it could be placed inline too (4 bytes) 

- the smaller version of 'usbCrc16' starts with
usbCrc16:
    mov     ptrL, argPtrL
    mov     ptrH, argPtrH
while the faster one starts with
usbCrc16:
    movw     ptrL, argPtrL
which does the same but is 2 bytes smaller.

- USB_INTR_VECTOR is no longer a real interrupt vector, but is called from the main program; so, it is not necessary to push/pop SREG and all the registers it uses, we need to save only the registers containing valid data (savings 20..30 bytes)

These are some of the more obvious things when looking at the disassembled code. I did not test any of the suggestions, because v2.04 does not run on my system (issue #151).

Someone wants to deal with it?

Thanks bitflipser
(How do I generate the nice red and green underlayed code change listings?)







 