### PR TITLE
Add low voltage tiny84 configuration.

### DIFF
--- a/firmware/configuration/t84_lowvoltage/Makefile.inc
+++ b/firmware/configuration/t84_lowvoltage/Makefile.inc
@@ -1,0 +1,63 @@
+# Name: Makefile
+# Project: Micronucleus
+# License: GNU GPL v2 (see License.txt)
+#
+# Controller type: ATtiny 84
+# Configuration:   Default configuration - 12 Mhz RC oscillator
+# Last Change:     Mar 16,2014
+ 
+
+F_CPU = 12000000
+DEVICE = attiny84
+
+# hexadecimal address for bootloader section to begin. To calculate the best value:
+# - make clean; make main.hex; ### output will list data: 2124 (or something like that)
+# - for the size of your device (8kb = 1024 * 8 = 8192) subtract above value 2124... = 6068
+# - How many pages in is that? 6068 / 64 (tiny85 page size in bytes) = 94.8125
+# - round that down to 94 - our new bootloader address is 94 * 64 = 6016, in hex = 1780
+BOOTLOADER_ADDRESS = 19C0
+
+FUSEOPT = -U lfuse:w:0x62:m -U hfuse:w:0xde:m -U efuse:w:0xfe:m
+FUSEOPT_DISABLERESET =  # TODO
+
+
+#---------------------------------------------------------------------
+# ATtiny84
+#---------------------------------------------------------------------
+# Fuse extended byte:
+# 0xFE = - - - -   - 1 1 0
+#                        ^
+#                        |
+#                        +---- SELFPRGEN (enable self programming flash)
+#
+# Fuse high byte:
+# 0xde = 1 1 0 1   1 1 1 0
+#        ^ ^ ^ ^   ^ \-+-/ 
+#        | | | |   |   +------ BODLEVEL 2..0 (brownout trigger level -> 2.7V)
+#        | | | |   +---------- EESAVE (preserve EEPROM on Chip Erase -> not preserved)
+#        | | | +-------------- WDTON (watchdog timer always on -> disable)
+#        | | +---------------- SPIEN (enable serial programming -> enabled)
+#        | +------------------ DWEN (debug wire enable)
+#        +-------------------- RSTDISBL (disable external reset -> enabled)
+#
+# Fuse high byte ("no reset": external reset disabled, can't program through SPI anymore)
+# 0x5d = 0 1 0 1   1 1 0 1
+#        ^ ^ ^ ^   ^ \-+-/ 
+#        | | | |   |   +------ BODLEVEL 2..0 (brownout trigger level -> 2.7V)
+#        | | | |   +---------- EESAVE (preserve EEPROM on Chip Erase -> not preserved)
+#        | | | +-------------- WDTON (watchdog timer always on -> disable)
+#        | | +---------------- SPIEN (enable serial programming -> enabled)
+#        | +------------------ DWEN (debug wire enable)
+#        +-------------------- RSTDISBL (disable external reset -> disabled!)
+#
+# Fuse low byte:
+# 0x62 = 0 1 1 0   0 0 1 0
+#        ^ ^ \+/   \--+--/
+#        | |  |       +------- CKSEL 3..0 (clock selection -> RC Oscillator)
+#        | |  +--------------- SUT 1..0 (BOD enabled, fast rising power)
+#        | +------------------ CKOUT (clock output on CKOUT pin -> disabled)
+#        +-------------------- CKDIV8 (divide clock by 8 -> don't divide)
+
+
+
+

--- a/firmware/configuration/t84_lowvoltage/bootloaderconfig.h
+++ b/firmware/configuration/t84_lowvoltage/bootloaderconfig.h
@@ -1,0 +1,283 @@
+/* Name: bootloaderconfig.h
+ * Micronucleus configuration file. 
+ * This file (together with some settings in Makefile.inc) configures the boot loader
+ * according to the hardware.
+ * 
+ * Controller type: ATtiny 84 - 12 MHz
+ * Configuration:   Configuration for non-bootloader operation down to 1.8V with 1 MHz internal RC
+ *       USB D- :   PB0
+ *       USB D+ :   PB1
+ *       Entry  :   Jumper on PB2
+ *       LED    :   PA3, Active Low
+ *       OSCCAL :   Revert to precalibrated value (8 MHz)
+ *       CKDIV  :   Revert to fused value
+ * Note: can use 12 MHz V-USB without PLL due to stable RC-osc in ATTiny84A
+ * Last Change:     Nov 21,2010
+ *
+ * License: GNU GPL v2 (see License.txt
+ */
+
+#ifndef __bootloaderconfig_h_included__
+#define __bootloaderconfig_h_included__
+
+/* ------------------------------------------------------------------------- */
+/*                       Hardware configuration.                             */
+/*      Change this according to your CPU and USB configuration              */
+/* ------------------------------------------------------------------------- */
+
+#define USB_CFG_IOPORTNAME      B
+  /* This is the port where the USB bus is connected. When you configure it to
+   * "B", the registers PORTB, PINB and DDRB will be used.
+   */
+
+#define USB_CFG_DMINUS_BIT      0
+/* This is the bit number in USB_CFG_IOPORT where the USB D- line is connected.
+ * This may be any bit in the port.
+ */
+#define USB_CFG_DPLUS_BIT       1
+/* This is the bit number in USB_CFG_IOPORT where the USB D+ line is connected.
+ * This may be any bit in the port, but must be configured as a pin change interrupt.
+ */
+
+#define USB_CFG_CLOCK_KHZ       (F_CPU/1000)
+/* Clock rate of the AVR in kHz. Legal values are 12000, 12800, 15000, 16000,
+ * 16500, 18000 and 20000. The 12.8 MHz and 16.5 MHz versions of the code
+ * require no crystal, they tolerate +/- 1% deviation from the nominal
+ * frequency. All other rates require a precision of 2000 ppm and thus a
+ * crystal!
+ * Since F_CPU should be defined to your actual clock rate anyway, you should
+ * not need to modify this setting.
+ */
+
+/* Special configuration needs: This device runs on a 3V Coin cell and needs to be stable down to 2V.
+That is why there is the need to have the CKDIV8 Fuse programmed, so bootloader execution actually starts with 1 MHz.
+Still, we set F_CPU to 12 MHz and calibrate using OSCAL. To not change code, LED_INIT is abused to
+reset the clock division
+*/
+
+/* ------------- Set up interrupt configuration (CPU specific) --------------   */
+/* The register names change quite a bit in the ATtiny family. Pay attention    */
+/* to the manual. Note that the interrupt flag system is still used even though */
+/* interrupts are disabled. So this has to be configured correctly.             */
+
+
+// setup interrupt for Pin Change for D+
+#define USB_INTR_CFG            PCMSK1
+#define USB_INTR_CFG_SET        (1 << USB_CFG_DPLUS_BIT)
+#define USB_INTR_CFG_CLR        0
+#define USB_INTR_ENABLE         GIMSK
+#define USB_INTR_ENABLE_BIT     PCIE1
+#define USB_INTR_PENDING        GIFR
+#define USB_INTR_PENDING_BIT    PCIF1
+#define USB_INTR_VECTOR         PCINT1_vect
+    
+/* ------------------------------------------------------------------------- */
+/*       Configuration relevant to the CPU the bootloader is running on      */
+/* ------------------------------------------------------------------------- */
+
+// how many milliseconds should host wait till it sends another erase or write?
+// needs to be above 4.5 (and a whole integer) as avr freezes for 4.5ms
+
+#define MICRONUCLEUS_WRITE_SLEEP 5
+
+// ATtiny84 does not know WDTCR
+#ifndef WDTCR
+#define WDTCR WDTCSR
+#endif
+
+/* ---------------------- feature / code size options ---------------------- */
+/*               Configure the behavior of the bootloader here               */
+/* ------------------------------------------------------------------------- */
+
+/*
+ *  Define Bootloader entry condition
+ * 
+ *  If the entry condition is not met, the bootloader will not be activated and the user program
+ *  is executed directly after a reset. If no user program has been loaded, the bootloader
+ *  is always active.
+ * 
+ *  ENTRY_ALWAYS        Always activate the bootloader after reset. Requires the least
+ *                      amount of code.
+ *
+ *  ENTRY_WATCHDOG      Activate the bootloader after a watchdog reset. This can be used
+ *                      to enter the bootloader from the user program.
+ *                      Adds 22 bytes.
+ *
+ *  ENTRY_EXT_RESET     Activate the bootloader after an external reset was issued by 
+ *                      pulling the reset pin low. It may be necessary to add an external
+ *                      pull-up resistor to the reset pin if this entry method appears to
+ *                      behave unreliably.
+ *                      Adds 22 bytes.
+ *
+ *  ENTRY_JUMPER        Activate the bootloader when a specific pin is pulled low by an 
+ *                      external jumper. 
+ *                      Adds 34 bytes.
+ *
+ *       JUMPER_PIN     Pin the jumper is connected to. (e.g. PB0)
+ *       JUMPER_PORT    Port out register for the jumper (e.g. PORTB)  
+ *       JUMPER_DDR     Port data direction register for the jumper (e.g. DDRB)  
+ *       JUMPER_INP     Port inout register for the jumper (e.g. PINB)  
+ * 
+ */
+
+/* This configuration is intended for a device running on a CR2032 coin cell.
+ * Voltage without USB attached can be as low as 2 V which is not stable on 12 MHz.
+ * Therefore, we need to keep out of the bootloader when USB is not connected.
+ */
+#define ENTRYMODE ENTRY_JUMPER
+
+#define JUMPER_PIN    PB2
+#define JUMPER_PORT   PORTB 
+#define JUMPER_DDR    DDRB 
+#define JUMPER_INP    PINB 
+ 
+/*
+  Internal implementation, don't change this unless you want to add an entrymode.
+*/ 
+ 
+#define ENTRY_ALWAYS    1
+#define ENTRY_WATCHDOG  2
+#define ENTRY_EXT_RESET 3
+#define ENTRY_JUMPER    4
+
+#if ENTRYMODE==ENTRY_ALWAYS
+  #define bootLoaderInit()
+  #define bootLoaderExit()
+  #define bootLoaderStartCondition() 1
+#elif ENTRYMODE==ENTRY_WATCHDOG
+  #define bootLoaderInit()
+  #define bootLoaderExit()
+  #define bootLoaderStartCondition() (MCUSR&_BV(WDRF))
+#elif ENTRYMODE==ENTRY_EXT_RESET
+  #define bootLoaderInit()
+  #define bootLoaderExit()
+  #define bootLoaderStartCondition() (MCUSR&_BV(EXTRF))
+#elif ENTRYMODE==ENTRY_JUMPER
+  // Enable pull up on jumper pin and delay to stabilize input    
+  #define bootLoaderInit()   {JUMPER_DDR&=~_BV(JUMPER_PIN);JUMPER_PORT|=_BV(JUMPER_PIN);_delay_ms(1);}
+  #define bootLoaderExit()   {JUMPER_PORT&=~_BV(JUMPER_PIN);}
+  #define bootLoaderStartCondition() (!(JUMPER_INP&_BV(JUMPER_PIN)))
+#else
+   #error "No entry mode defined"
+#endif
+
+/*
+ * Define bootloader timeout value. 
+ * 
+ *  The bootloader will only time out if a user program was loaded.
+ * 
+ *  AUTO_EXIT_NO_USB_MS        The bootloader will exit after this delay if no USB is connected.
+ *                             Set to 0 to disable
+ *                             Adds ~6 bytes.
+ *                             (This will wait for an USB SE0 reset from the host)
+ *
+ *  AUTO_EXIT_MS               The bootloader will exit after this delay if no USB communication
+ *                             from the host tool was received.
+ *                             Set to 0 to disable
+ *  
+ *  All values are approx. in milliseconds
+ */
+
+#define AUTO_EXIT_NO_USB_MS    0
+#define AUTO_EXIT_MS           2000
+
+ /*
+ *  Defines the setting of the RC-oscillator calibration after quitting the bootloader. (OSCCAL)
+ * 
+ *  OSCCAL_RESTORE_DEFAULT    Set this to '1' to revert to OSCCAL factore calibration after bootlaoder exit.
+ *                            This is 8 MHz +/-2% on most devices or 16 MHz on the ATtiny 85 with activated PLL.
+ *                            Adds ~14 bytes.
+ *
+ *  OSCCAL_SAVE_CALIB         Set this to '1' to save the OSCCAL calibration during program upload.
+ *                            This value will be reloaded after reset and will also be used for the user
+ *                            program unless "OSCCAL_RESTORE_DEFAULT" is active. This allows calibrate the internal
+ *                            RC oscillator to the F_CPU target frequency +/-1% from the USB timing. Please note
+ *                            that only true if the ambient temperature does not change.
+ *                            Adds ~38 bytes.
+ *
+ *  OSCCAL_HAVE_XTAL          Set this to '1' if you have an external crystal oscillator. In this case no attempt
+ *                            will be made to calibrate the oscillator. You should deactivate both options above
+ *                            if you use this to avoid redundant code.
+ *
+ *  If both options are selected, OSCCAL_RESTORE_DEFAULT takes precedence.
+ *
+ *  If no option is selected, OSCCAL will be left untouched and stays at either factory calibration or F_CPU depending
+ *  on whether the bootloader was activated. This will take the least memory. You can use this if your program
+ *  comes with its own OSCCAL calibration or an external clock source is used. 
+ */
+ 
+#define OSCCAL_RESTORE_DEFAULT 1
+/* We must not set this to 1, otherwise the OSCAL is also restored when we don't want the bootloader to run */
+#define OSCCAL_SAVE_CALIB 0
+#define OSCCAL_HAVE_XTAL 0
+
+/*
+ * For certain operating conditions, device might have CKDIV8 fuse programmed. This clears CKDIV to 0 on bootloader entrance.
+ */
+#define CKDIV_RESET 1
+#define CKDIV_RESTORE_DEFAULT 1
+  
+/*  
+ *  Defines handling of an indicator LED while the bootloader is active.  
+ * 
+ *  LED_MODE                  Define behavior of attached LED or suppress LED code.
+ *
+ *          NONE              Do not generate LED code (gains 18 bytes).
+ *          ACTIVE_HIGH       LED is on when output pin is high. This will toggle bettwen 1 and 0.
+ *          ACTIVE_LOW        LED is on when output pin is low.  This will toggle between Z and 0.
+ *
+ *  LED_DDR,LED_PORT,LED_PIN  Where is your LED connected?
+ *
+ */ 
+
+#define LED_MODE    ACTIVE_LOW
+
+#define LED_DDR     DDRA
+#define LED_PORT    PORTA
+#define LED_PIN     PA3
+
+/*
+ *  This is the implementation of the LED code. Change the configuration above unless you want to 
+ *  change the led behavior
+ *
+ *  LED_INIT                  Called once after bootloader entry
+ *  LED_EXIT                  Called once during bootloader exit
+ *  LED_MACRO                 Called in the main loop with the idle counter as parameter.
+ *                            Use to define pattern.
+*/
+
+#define NONE        0
+#define ACTIVE_HIGH 1
+#define ACTIVE_LOW  2
+
+#if LED_MODE==ACTIVE_HIGH
+  #define LED_INIT(x)   LED_DDR   = _BV(LED_PIN); 
+  #define LED_EXIT(x)   {LED_DDR  &=~_BV(LED_PIN);LED_PORT  &=~_BV(LED_PIN);}
+  #define LED_MACRO(x)  if ( x & 0x4c ) {LED_PORT&=~_BV(LED_PIN);} else {LED_PORT|=_BV(LED_PIN);}
+#elif LED_MODE==ACTIVE_LOW
+  #define LED_INIT(x)   LED_PORT &=~_BV(LED_PIN);
+  #define LED_EXIT(x)   LED_DDR  &=~_BV(LED_PIN);
+  #define LED_MACRO(x)  if ( x & 0x4c ) {LED_DDR&=~_BV(LED_PIN);} else {LED_DDR|=_BV(LED_PIN);}  
+#elif LED_MODE==NONE
+  #define LED_INIT(x)
+  #define LED_EXIT(x)
+  #define LED_MACRO(x)
+#endif
+
+/* --------------------------------------------------------------------------- */
+/* Micronucleus internal configuration. Do not change anything below this line */
+/* --------------------------------------------------------------------------- */
+
+// Microcontroller vectortable entries in the flash
+#define RESET_VECTOR_OFFSET         0
+
+// number of bytes before the boot loader vectors to store the tiny application vector table
+#define TINYVECTOR_RESET_OFFSET     4
+#define TINYVECTOR_OSCCAL_OFFSET    6
+
+/* ------------------------------------------------------------------------ */
+// postscript are the few bytes at the end of programmable memory which store tinyVectors
+#define POSTSCRIPT_SIZE 6
+#define PROGMEM_SIZE (BOOTLOADER_ADDRESS - POSTSCRIPT_SIZE) /* max size of user program */
+
+#endif /* __bootloader_h_included__ */

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -69,7 +69,10 @@ PROGMEM const uint8_t configurationReply[6] = {
   
 #if OSCCAL_RESTORE_DEFAULT
   register uint8_t      osccal_default  asm("r2");
-#endif 
+#endif
+#if CKDIV_RESTORE_DEFAULT
+  register uint8_t      ckdiv_default   asm("r8");
+#endif
 
 register uint16_union_t currentAddress  asm("r4");  // r4/r5 current progmem address, used for erasing and writing 
 register uint16_union_t idlePolls       asm("r6");  // r6/r7 idlecounter
@@ -280,6 +283,13 @@ int main(void) {
 #endif
   
   if (bootLoaderStartCondition()||(pgm_read_byte(BOOTLOADER_ADDRESS - TINYVECTOR_RESET_OFFSET + 1)==0xff)) {
+    #if CKDIV_RESTORE_DEFAULT
+      ckdiv_default = CLKPR;
+    #endif
+    #if CKDIV_RESET
+      CLKPR=0x80;
+      CLKPR=0x00;
+    #endif
   
     initHardware();        
     LED_INIT();
@@ -394,6 +404,11 @@ int main(void) {
     
     USB_INTR_ENABLE = 0;
     USB_INTR_CFG = 0;       /* also reset config bits */
+    #if CKDIV_RESTORE_DEFAULT
+      CLKPR = 1<<CLKPCE;
+      CLKPR = ckdiv_default;
+    #endif
+
  
   }
    


### PR DESCRIPTION
This configuration allows operating the controller down to 1.8V as long as the bootloader is not activated (e.g. entry condition not met).
This allows for coin cell operation, still not losing bootloader functionality when a USB cable is plugged.

This branch build upon https://github.com/micronucleus/micronucleus/pull/162 and can be seen of an example implementation.
