### PR TITLE
Don't buffer plug in message, display timeout

### DIFF
--- a/commandline/micronucleus.c
+++ b/commandline/micronucleus.c
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
    * buffered by the IDE, so Micronucleus would appear to silently
    * hang otherwise.
    */
-  fprintf(stderr, "> Please plug in or reset the device");
+  fprintf(stderr, "> Please plug in the device");
   if (timeout > 0) fprintf(stderr, " (will time out in %d seconds)", timeout);
   fprintf(stderr, " ...\n");
   fprintf(stderr, "> Press CTRL-C to terminate the program.\n");

--- a/commandline/micronucleus.c
+++ b/commandline/micronucleus.c
@@ -158,11 +158,17 @@ int main(int argc, char **argv) {
 
   setProgressData("waiting", 1);
   if (dump_progress) printProgress(0.5);
+
+ /*
+   * For compatibility with the Arduino IDE, these messages should be
+   * written to stderr where they will be seen immediately; stdout is
+   * buffered by the IDE, so Micronucleus would appear to silently
+   * hang otherwise.
+   */
   fprintf(stderr, "> Please plug in or reset the device");
   if (timeout > 0) fprintf(stderr, " (will time out in %d seconds)", timeout);
   fprintf(stderr, " ...\n");
   fprintf(stderr, "> Press CTRL-C to terminate the program.\n");
-
 
   time_t start_time, current_time;
   time(&start_time);

--- a/commandline/micronucleus.c
+++ b/commandline/micronucleus.c
@@ -155,8 +155,10 @@ int main(int argc, char **argv) {
 
   setProgressData("waiting", 1);
   if (dump_progress) printProgress(0.5);
-  printf("> Please plug in the device ... \n");
-  printf("> Press CTRL+C to terminate the program.\n");
+  printf("> Please plug in or reset the device");
+  if (timeout > 0) printf(" (will time out in %d seconds)", timeout);
+  printf(" ...\n");
+  printf("> Press CTRL-C to terminate the program.\n");
 
 
   time_t start_time, current_time;
@@ -173,7 +175,7 @@ int main(int argc, char **argv) {
   }
 
   if (my_device == NULL) {
-    printf("> Device search timed out\n");
+    printf("> Device search timed out!\n");
     return EXIT_FAILURE;
   }
 

--- a/commandline/micronucleus.c
+++ b/commandline/micronucleus.c
@@ -137,9 +137,12 @@ int main(int argc, char **argv) {
     } else if (strcmp(argv[arg_pointer], "--timeout") == 0) {
       arg_pointer += 1;
       if (sscanf(argv[arg_pointer], "%d", &timeout) != 1) {
-        printf("Did not understand --timeout value\n");
+        fprintf(stderr, "Did not understand --timeout value: %s\n", argv[arg_pointer]);
         return EXIT_FAILURE;
       }
+    } else if (argv[arg_pointer][0] == '-') {
+      fprintf(stderr, "Unrecognized option: %s\n", argv[arg_pointer]);
+      return EXIT_FAILURE;
     } else {
       file = argv[arg_pointer];
     }
@@ -155,10 +158,10 @@ int main(int argc, char **argv) {
 
   setProgressData("waiting", 1);
   if (dump_progress) printProgress(0.5);
-  printf("> Please plug in or reset the device");
-  if (timeout > 0) printf(" (will time out in %d seconds)", timeout);
-  printf(" ...\n");
-  printf("> Press CTRL-C to terminate the program.\n");
+  fprintf(stderr, "> Please plug in or reset the device");
+  if (timeout > 0) fprintf(stderr, " (will time out in %d seconds)", timeout);
+  fprintf(stderr, " ...\n");
+  fprintf(stderr, "> Press CTRL-C to terminate the program.\n");
 
 
   time_t start_time, current_time;


### PR DESCRIPTION
Currently, when micronucleus is called from an Arduino core, it is called via a wrapper called launcher.  One of the things this launcher does is work around a few issues in the messages micronucleus prints.  Now that micronucleus is integrated into a core with is currently maintained, it would be a good time to fix some of these issues to obviate the wrapper program.

This PR makes the following improvements:

* print messages to the correct stream; errors and other messages now go to _stderr_.  In Arduino, _stdout_ is buffered, while _stderr_ is displayed immediately, so it's critical to write the _plug in now_ message to stderr.
* if a timeout is specified, it should display in the message.  An arduino user may not know what timeout is specified by the core they're using, so it is currently included in the message by the launcher wrapper.
* add _or reset_ to the message, since many devices where this is used don't have their reset pin disabled, so users may connect a button to it rather than physically replug it.
* when an error is detected, display some more information about the error.
* detect unrecognized options, rather than treating them as file names.