### PR TITLE
Add github-actions autobuild of CLI tools

### DIFF
--- a/.github/workflows/build-pkg.sh
+++ b/.github/workflows/build-pkg.sh
@@ -1,0 +1,44 @@
+#! /bin/sh
+
+PKG_NAME=micronucleus-cli
+WORKSPACE_DIR=$(pwd)
+cd commandline
+
+case $BUILD_OS in
+  Windows)
+    mingw32-make USBLIBS=-lusb0
+    ZIPLIB=/mingw64/bin/libusb*.dll
+    EXE_EXT=.exe
+    ;;
+  macOS)
+    make USBFLAGS=$(PKG_CONFIG_PATH=$(brew --prefix libusb-compat)/lib/pkgconfig pkg-config --cflags libusb) \
+         USBLIBS="$(PKG_CONFIG_PATH=$(brew --prefix libusb-compat)/lib/pkgconfig pkg-config --libs libusb) -lusb"
+    ZIPLIB=$(find $(brew --prefix libusb-compat)/lib -name "*dylib" -type f -depth 1)
+    ;;
+  Linux)
+    make
+    ;;
+esac
+
+g++ -o launcher${EXE_EXT} avr-dummy/avrdude-dummy.cpp
+
+RELEASE_FILE=$PKG_NAME-$(uname -m)-$(uname -s).zip
+mkdir $PKG_NAME
+if [ -n "$ZIPLIB" ]; then eval "cp -p $ZIPLIB $PKG_NAME"; ZIPLIB=$(basename "$ZIPLIB"); fi
+cp -p micronucleus${EXE_EXT} launcher${EXE_EXT} $PKG_NAME
+eval zip -r $WORKSPACE_DIR/$RELEASE_FILE $PKG_NAME
+
+## Prepare release and artifact upload
+
+case $GITHUB_REF in
+    refs/tags/*)
+        RELEASE_TAG=$(basename $GITHUB_REF)
+        ;;
+    refs/heads/*)
+        RELEASE_BRANCH=$(basename $GITHUB_REF)
+        ;;
+esac
+for release_item in TAG BRANCH FILE
+do
+  eval echo "::set-output name=RELEASE_$release_item::\$RELEASE_$release_item"
+done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,70 @@
+name: Build CLI tools
+
+on:
+  push:
+    branches:
+        - '*'
+    tags:
+        - '*'
+        - '!*-LATEST'
+
+jobs:
+  build-all:
+    strategy:
+      matrix:
+         include:
+         - os: ubuntu-latest
+           shell: bash
+         - os: macos-latest
+           shell: bash
+         - os: windows-2019
+           shell: msys2 {0}
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    steps:
+    - name: install dependencies
+      run: sudo sh -c "apt-get update && apt-get install libusb-dev"
+      if: runner.os == 'Linux'
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        install: git base-devel binutils mingw-w64-x86_64-toolchain make zip mingw-w64-x86_64-libusb-win32
+        update: true
+      if: runner.os == 'Windows'
+
+    - name: install dependencies
+      run: brew install libusb-compat
+      if: runner.os == 'macOS'
+
+    - uses: actions/checkout@v2
+
+    - name: make
+      id: make
+      env:
+        BUILD_OS: ${{ runner.os }}
+      run: |
+          bash -x $GITHUB_WORKSPACE/.github/workflows/build-pkg.sh
+
+    - name: Branch head release
+      uses: johnwbyrd/update-release@v1.0.0
+      if: steps.make.outputs.RELEASE_BRANCH != ''
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        release: "${{ steps.make.outputs.RELEASE_BRANCH }}-LATEST"
+        tag: "${{ steps.make.outputs.RELEASE_BRANCH }}-LATEST"
+        prerelease: true
+        message: "Development build on branch ${{ steps.make.outputs.RELEASE_BRANCH }}"
+        files: ${{ steps.make.outputs.RELEASE_FILE }}
+
+    - name: Tagged release
+      uses: johnwbyrd/update-release@v1.0.0
+      if: steps.make.outputs.RELEASE_TAG != ''
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: false
+        message: "Release build ${{ steps.make.outputs.RELEASE_TAG }}"
+        files: ${{ steps.make.outputs.RELEASE_FILE }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "commandline/avr-dummy"]
+	path = commandline/avr-dummy
+	url = https://github.com/digistump/avr-dummy


### PR DESCRIPTION
This PR adds Github actions to generate Linux, MacOS, and Windows binaries automatically for the micronucleus CLI tools, so that those who depend on them to package Arduino cores (e.g. @ArminJo , @SpenceKonde) don't have to build them themselves.