### PR TITLE
For builds on a branch, delete previous tag and release

### DIFF
--- a/.github/workflows/build-pkg.sh
+++ b/.github/workflows/build-pkg.sh
@@ -24,6 +24,7 @@ RELEASE_FILE=$PKG_NAME-$(uname -m)-$(uname -s).zip
 mkdir $PKG_NAME
 if [ -n "$ZIPLIB" ]; then eval "cp -p $ZIPLIB $PKG_NAME"; ZIPLIB=$(basename "$ZIPLIB"); fi
 cp -p micronucleus${EXE_EXT} $PKG_NAME
+echo "Built on $(date) from $GITHUB_REF:$GITHUB_SHA" > $PKG_NAME/BUILD_INFO
 eval zip -r $WORKSPACE_DIR/$RELEASE_FILE $PKG_NAME
 
 ## Prepare release and artifact upload

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,22 @@ on:
         - '!*-LATEST'
 
 jobs:
+  delete-previous-branch-release:
+      runs-on: ubuntu-latest
+      if: startswith(github.ref, 'refs/heads/')
+      steps:
+          - name: compute branch name
+            id: compute-branch
+            run: echo "${{ github.ref }}" | sed "s,^refs/heads/,::set-output name=RELEASE_BRANCH::,"
+          - uses: dev-drprasad/delete-tag-and-release@v0.1.2
+            with:
+                delete_release: true # default: false
+                tag_name: "${{ steps.compute-branch.outputs.RELEASE_BRANCH }}-LATEST"
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-all:
+    needs: delete-previous-branch-release
     strategy:
       matrix:
          include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,12 @@ on:
 jobs:
   delete-previous-branch-release:
       runs-on: ubuntu-latest
-      if: startswith(github.ref, 'refs/heads/')
       steps:
           - name: compute branch name
             id: compute-branch
             run: echo "${{ github.ref }}" | sed "s,^refs/heads/,::set-output name=RELEASE_BRANCH::,"
           - uses: dev-drprasad/delete-tag-and-release@v0.1.2
+            if: startswith(github.ref, 'refs/heads/')
             with:
                 delete_release: true # default: false
                 tag_name: "${{ steps.compute-branch.outputs.RELEASE_BRANCH }}-LATEST"


### PR DESCRIPTION
This ensures that the -LATEST tag and release will be updated to the current branch tip and receive the latest build artefacts.
(Otherwise the `johnwbyrd/update-release` action does not update an existing tag/release).