### PR TITLE
commandline: allow -static to be overriden easily.

### DIFF
--- a/commandline/Makefile
+++ b/commandline/Makefile
@@ -8,9 +8,9 @@ CC=gcc
 ifeq ($(shell uname), Linux)
 # If you get the error "usb.h: No such file or directory" you must run "sudo apt-get install libusb-dev"
 	USBFLAGS=$(shell libusb-config --cflags)
-	USBLIBS= -static $(shell libusb-config --libs)
-# If you get an error about missing USB libraries, please use the line below instead of the one above
-#	USBLIBS= $(shell libusb-config --libs)
+	# If you get an error about missing USB libraries, unset STATIC
+	STATIC = -static
+	USBLIBS= $(STATIC) $(shell libusb-config --libs)
 	EXE_SUFFIX =
 	OSFLAG = -D LINUX
 else ifeq ($(shell uname), Darwin)

--- a/commandline/Readme
+++ b/commandline/Readme
@@ -3,6 +3,7 @@ ihsan Kehribar <ihsan@kehribar.me> and Bluebie <a@creativepony.com>
 
 It's been tested casually on Mac, Windows, and Linux, and aught to work on all
 three. To make and install, do the regular 'make; sudo make install' on unixes.
+If you're on linux and don't want a static binary, use 'make STATIC=' instead.
 
 If you get the error "usb.h: No such file or directory" you must run "sudo apt-get install libusb-dev".
 


### PR DESCRIPTION
This way, someone building it needs only to use `make STATIC=` to result
in a dynamic binary.

Also fix comment indentation.