### PR TITLE
commandline: Add support for Homebrew libusb on Mac OS X.

### DIFF
--- a/commandline/Makefile
+++ b/commandline/Makefile
@@ -1,5 +1,6 @@
 # Makefile initially writen for Little-Wire by Omer Kilic <omerkilic@gmail.com>
 # Later on modified by ihsan Kehribar <ihsan@kehribar.me> for Micronucleus bootloader application.
+# 2021-07-25: Modified by Toby Thain <toby@telegraphics.com.au> for OS X Homebrew libusb packages.
 
 SHELL := /bin/bash
 
@@ -14,15 +15,29 @@ ifeq ($(shell uname), Linux)
 	EXE_SUFFIX =
 	OSFLAG = -D LINUX
 else ifeq ($(shell uname), Darwin)
-	USBFLAGS=$(shell libusb-config --cflags || libusb-legacy-config --cflags)
-	EXE_SUFFIX =
-	OSFLAG = -D MAC_OS
-	USBLIBS = /usr/local/opt/libusb-compat/lib/libusb.a
-	USBLIBS += /usr/local/opt/libusb/lib/libusb-1.0.a
-	USBLIBS += -framework CoreFoundation
-	USBLIBS += -framework IOKit
-	# Uncomment these to create a dual architecture binary:
-	# OSFLAG += -arch x86_64 -arch i386
+	# if pkg-config is available, use it
+	# This assumes libusb (and pkg-config if necessary) have been
+	# installed by `brew install pkg-config libusb libusb-compat`
+	# Tested with OS X Mojave 10.14.6
+	ifneq ($(shell which pkg-config), "")
+		# Unfortunately, Homebrew does not install the .pc file
+		# in a version independent location
+		PCPATH = $(shell dirname `brew list libusb | grep libusb-1.0.pc`)
+		USBFLAGS += $(shell PKG_CONFIG_PATH=$(PCPATH) pkg-config --cflags libusb)
+		USBLIBS += $(shell PKG_CONFIG_PATH=$(PCPATH) pkg-config --libs libusb libusb-1.0)
+		EXE_SUFFIX =
+		OSFLAG = -D MAC_OS -D MAC_OS_PKGCONFIG
+	else
+		USBFLAGS=$(shell libusb-config --cflags || libusb-legacy-config --cflags)
+		EXE_SUFFIX =
+		OSFLAG = -D MAC_OS
+		USBLIBS = /usr/local/opt/libusb-compat/lib/libusb.a
+		USBLIBS += /usr/local/opt/libusb/lib/libusb-1.0.a
+		USBLIBS += -framework CoreFoundation
+		USBLIBS += -framework IOKit
+		# Uncomment these to create a dual architecture binary:
+		# OSFLAG += -arch x86_64 -arch i386
+	endif
 else ifeq ($(shell uname), OpenBSD)
 	USBFLAGS=$(shell libusb-config --cflags || libusb-legacy-config --cflags)
 	USBLIBS=$(shell libusb-config --libs || libusb-legacy-config --libs)

--- a/commandline/Readme
+++ b/commandline/Readme
@@ -8,7 +8,11 @@ If you're on linux and don't want a static binary, use 'make STATIC=' instead.
 If you get the error "usb.h: No such file or directory" you must run "sudo apt-get install libusb-dev".
 
 Building on windows requires mingw32+msys with lib-winusb32. Possibly it can also
-be built with mingw64. 
+be built with mingw64.
+
+If building on Mac, you can choose to use Homebrew packages for libusb.
+To do this, first run `brew install pkg-config libusb libusb-compat`,
+then `make` (tested with OS X Mojave 10.14.6).
 
 Usage on Ubuntu:
   sudo micronucleus --run name_of_the_file.hex


### PR DESCRIPTION
Not sure if the existing OS X make script did once work with Homebrew, but it makes assumptions that don't hold with current Homebrew. I've added a clause that should work out of the box, and added a paragraph to the Readme.