### PR TITLE
Update 49-micronucleus.rules

### DIFF
--- a/commandline/49-micronucleus.rules
+++ b/commandline/49-micronucleus.rules
@@ -5,8 +5,9 @@
 #   or
 # /lib/udev/rules.d/49-micronucleus.rules    (req'd on some broken systems)
 #
-# To install, type this command in a terminal:
+# To install, type these commands in a terminal:
 #   sudo cp 49-micronucleus.rules /etc/udev/rules.d/49-micronucleus.rules
+#   sudo udevadm control --reload-rules
 #
 # After this file is copied, physically unplug and reconnect the board.
 #


### PR DESCRIPTION
The Linux udev rules need an extra command to be activated, else they don't work until a reboot...