### PR TITLE
Add WinUSB feature descriptors

### DIFF
--- a/firmware/CalculateSize.py
+++ b/firmware/CalculateSize.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 # calculate bootloader location and free userspace
 
 import sys

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -105,7 +105,7 @@ main.hex:	main.bin
 	@avr-size main.hex
 #   if you don't have python installed, you can comment out the next three lines and use the two above
 	@avr-size -A -t main.hex >size.txt
-	@python CalculateSize.py <size.txt
+	@python3 CalculateSize.py <size.txt
 	@rm size.txt
 
 disasm:	main.bin upgrade.bin

--- a/firmware/bootloader.h
+++ b/firmware/bootloader.h
@@ -1,0 +1,5 @@
+extern const uint8_t bootloader[] PROGMEM;
+extern const uint8_t bootloader_end[] PROGMEM;
+extern const uint8_t bootloader_size_sym[];
+#define bootloader_size ( (int) bootloader_size_sym )
+#define bootloader_address 0x1940

--- a/firmware/configuration/t85_winusb/Makefile.inc
+++ b/firmware/configuration/t85_winusb/Makefile.inc
@@ -1,0 +1,63 @@
+# Name: Makefile
+# Project: Micronucleus
+# License: GNU GPL v2 (see License.txt)
+
+# Controller type: ATtiny 85 - 16.5 MHz
+# Configuration:   Default
+# Last Change:     Jun 16,2020
+
+F_CPU = 16500000
+DEVICE = attiny85
+
+# hexadecimal address for bootloader section to begin. To calculate the best value:
+# - make clean; make main.hex; ### output will list data: 1592 (or something like that)
+# - for the size of your device (8kb = 1024 * 8 = 8192) subtract above value = 6598
+# - How many pages in is that? 6598 / 64 (tiny85 page size in bytes) = 103.09377
+# - round that down to 103 - our new bootloader address is 103 * 64 = 6592, in hex = 19C0
+# - The available size for user program is (BOOTLOADER_ADDRESS - POSTSCRIPT_SIZE) with POSTSCRIPT_SIZE = 4 or 6
+# - For data size from 1470 up to 1536 the address is 1A00 (6650 free),
+# - for 1538 to 1600 it is 19C0 (6586 free), for 1602 to 1664 it is 1980 (6522 free)
+# - The WinUSB feature descriptor takes a whopping 1716 bytes! So it needs 1940 (6458 free) - this is a bit much.
+BOOTLOADER_ADDRESS = 1940
+
+FUSEOPT = -U lfuse:w:0xe1:m -U hfuse:w:0xdd:m -U efuse:w:0xfe:m
+FUSEOPT_DISABLERESET = -U lfuse:w:0xe1:m -U efuse:w:0xfe:m -U hfuse:w:0x5d:m
+
+#---------------------------------------------------------------------
+# ATtiny85
+#---------------------------------------------------------------------
+# Fuse extended byte:
+# 0xFE = - - - -   - 1 1 0
+#                        ^
+#                        |
+#                        +---- SELFPRGEN (enable self programming flash)
+#
+# Fuse high byte:
+# 0xdd = 1 1 0 1   1 1 0 1
+#        ^ ^ ^ ^   ^ \-+-/
+#        | | | |   |   +------ BODLEVEL 2..0 (brownout trigger level -> 2.7V)
+#        | | | |   +---------- EESAVE (preserve EEPROM on Chip Erase -> not preserved)
+#        | | | +-------------- WDTON (watchdog timer always on -> disable)
+#        | | +---------------- SPIEN (enable serial programming -> enabled)
+#        | +------------------ DWEN (debug wire enable)
+#        +-------------------- RSTDISBL (disable external reset -> enabled)
+#
+# Fuse high byte ("no reset": external reset disabled, can't program through SPI anymore)
+# 0x5d = 0 1 0 1   1 1 0 1
+#        ^ ^ ^ ^   ^ \-+-/
+#        | | | |   |   +------ BODLEVEL 2..0 (brownout trigger level -> 2.7V)
+#        | | | |   +---------- EESAVE (preserve EEPROM on Chip Erase -> not preserved)
+#        | | | +-------------- WDTON (watchdog timer always on -> disable)
+#        | | +---------------- SPIEN (enable serial programming -> enabled)
+#        | +------------------ DWEN (debug wire enable)
+#        +-------------------- RSTDISBL (disable external reset -> disabled!)
+#
+# Fuse low byte:
+# 0xe1 = 1 1 1 0   0 0 0 1
+#        ^ ^ \+/   \--+--/
+#        | |  |       +------- CKSEL 3..0 (clock selection -> HF PLL)
+#        | |  +--------------- SUT 1..0 (BOD enabled, fast rising power)
+#        | +------------------ CKOUT (clock output on CKOUT pin -> disabled)
+#        +-------------------- CKDIV8 (divide clock by 8 -> don't divide)
+
+###############################################################################

--- a/firmware/configuration/t85_winusb/Makefile.inc
+++ b/firmware/configuration/t85_winusb/Makefile.inc
@@ -17,8 +17,7 @@ DEVICE = attiny85
 # - The available size for user program is (BOOTLOADER_ADDRESS - POSTSCRIPT_SIZE) with POSTSCRIPT_SIZE = 4 or 6
 # - For data size from 1470 up to 1536 the address is 1A00 (6650 free),
 # - for 1538 to 1600 it is 19C0 (6586 free), for 1602 to 1664 it is 1980 (6522 free)
-# - The WinUSB feature descriptor takes a whopping 1716 bytes! So it needs 1940 (6458 free) - this is a bit much.
-BOOTLOADER_ADDRESS = 1940
+BOOTLOADER_ADDRESS = 1980
 
 FUSEOPT = -U lfuse:w:0xe1:m -U hfuse:w:0xdd:m -U efuse:w:0xfe:m
 FUSEOPT_DISABLERESET = -U lfuse:w:0xe1:m -U efuse:w:0xfe:m -U hfuse:w:0x5d:m

--- a/firmware/configuration/t85_winusb/bootloaderconfig.h
+++ b/firmware/configuration/t85_winusb/bootloaderconfig.h
@@ -1,0 +1,326 @@
+/* Name: bootloaderconfig.h
+ * Micronucleus configuration file.
+ * This file (together with some settings in Makefile.inc) configures the boot loader
+ * according to the hardware.
+ *
+ * Controller type: ATtiny 85 - 16.5 MHz
+ * Configuration:   Default configuration
+ *       USB D- :   PB3
+ *       USB D+ :   PB4
+ *       Entry  :   Always
+ *       LED    :   None
+ *       OSCCAL :   Stays at 16 MHz
+ * Note: Uses 16.5 MHz V-USB implementation with PLL
+ *
+ * License: GNU GPL v2 (see License.txt
+ */
+#ifndef __bootloaderconfig_h_included__
+#define __bootloaderconfig_h_included__
+
+/* ------------------------------------------------------------------------- */
+/*                       Hardware configuration.                             */
+/*      Change this according to your CPU and USB configuration              */
+/* ------------------------------------------------------------------------- */
+
+#define USB_CFG_IOPORTNAME      B
+  /* This is the port where the USB bus is connected. When you configure it to
+   * "B", the registers PORTB, PINB and DDRB will be used.
+   */
+
+#define USB_CFG_DMINUS_BIT      3
+/* This is the bit number in USB_CFG_IOPORT where the USB D- line is connected.
+ * This may be any bit in the port.
+ * USB- has a 1.5k pullup resistor to indicate a low-speed device.
+ */
+#define USB_CFG_DPLUS_BIT       4
+/* This is the bit number in USB_CFG_IOPORT where the USB D+ line is connected.
+ * This may be any bit in the port, but must be configured as a pin change interrupt.
+ */
+
+#define USB_CFG_CLOCK_KHZ       (F_CPU/1000)
+/* Clock rate of the AVR in kHz. Legal values are 12000, 12800, 15000, 16000,
+ * 16500, 18000 and 20000. The 12.8 MHz and 16.5 MHz versions of the code
+ * require no crystal, they tolerate +/- 1% deviation from the nominal
+ * frequency. All other rates require a precision of 2000 ppm and thus a
+ * crystal!
+ * Since F_CPU should be defined to your actual clock rate anyway, you should
+ * not need to modify this setting.
+ */
+
+/* ----------------------- Optional Hardware Config ------------------------ */
+//#define USB_CFG_PULLUP_IOPORTNAME   B
+/* If you connect the 1.5k pullup resistor from D- to a port pin instead of
+ * V+, you can connect and disconnect the device from firmware by calling
+ * the macros usbDeviceConnect() and usbDeviceDisconnect() (see usbdrv.h).
+ * This constant defines the port on which the pullup resistor is connected.
+ */
+//#define USB_CFG_PULLUP_BIT          0
+/* This constant defines the bit number in USB_CFG_PULLUP_IOPORT (defined
+ * above) where the 1.5k pullup resistor is connected. See description
+ * above for details.
+ */
+
+/* ------------- Set up interrupt configuration (CPU specific) --------------   */
+/* The register names change quite a bit in the ATtiny family. Pay attention    */
+/* to the manual. Note that the interrupt flag system is still used even though */
+/* interrupts are disabled. So this has to be configured correctly.             */
+
+// setup interrupt for Pin Change for D+
+#define USB_INTR_CFG            PCMSK // Pin interrupt enable register
+#define USB_INTR_CFG_SET        (1 << USB_CFG_DPLUS_BIT) // Mask for pin in pin interrupt enable register PCMSK to be set on usbInit
+#define USB_INTR_CFG_CLR        0 // Mask for pin in pin interrupt enable register PCMSK to be cleared on usbInit. 0 = no clear
+#define USB_INTR_ENABLE         GIMSK // Global interrupt enable register
+#define USB_INTR_ENABLE_BIT     PCIE  // Bit position in global interrupt enable register
+#define USB_INTR_PENDING        GIFR  // Register to read interrupt flag
+#define USB_INTR_PENDING_BIT    PCIF  // Bit position in register to read interrupt flag
+
+// Theoretical this should work, but I get "Starting to upload ... >> Flash write error: Input/output error has occured" when a application is still loaded
+//#define USB_INTR_CFG            MCUCR // requires 4 bit extra code size since sbi is not possible for MCUCR
+//#define USB_INTR_CFG_SET        (1 << ISC00)
+//#define USB_INTR_CFG_CLR        0
+//#define USB_INTR_ENABLE         GIMSK
+//#define USB_INTR_ENABLE_BIT     INT0
+//#define USB_INTR_PENDING        GIFR
+//#define USB_INTR_PENDING_BIT    INTF0
+
+/* ------------------------------------------------------------------------- */
+/*       Configuration relevant to the CPU the bootloader is running on      */
+/* ------------------------------------------------------------------------- */
+
+// how many milliseconds should host wait till it sends another erase or write?
+// needs to be above 4.5 (and a whole integer) as avr freezes maximum for 4.5ms
+// while writing a FLASH page (even for 128 byte page size:-))
+#define MICRONUCLEUS_WRITE_SLEEP 5
+
+
+/* ---------------------- feature / code size options ---------------------- */
+/*               Configure the behavior of the bootloader here               */
+/* ------------------------------------------------------------------------- */
+
+/*
+ *  Define Bootloader entry condition
+ *
+ *  If the entry condition is not met, the bootloader will not be activated and the user program
+ *  is executed directly after a reset. If no user program has been loaded, the bootloader
+ *  is always active.
+ *
+ *  ENTRY_ALWAYS        Always activate the bootloader after reset. Requires the least
+ *                      amount of code.
+ *
+ *  ENTRY_POWER_ON      Activate the bootloader after power on. This is what you need
+ *                      for normal development with Digispark boards.
+ *                      !!! If SAVE_MCUSR (below) is NOT defined !!!
+ *                      Since the reset flags are no longer cleared by micronucleus
+ *                      you must clear them with "MCUSR = 0;" in your setup() routine
+ *                      after saving or evaluating them to make this mode work.
+ *                      If you do not reset the flags, the bootloader will be entered even
+ *                      after reset, since the "power on reset flag" PORF in MCUSR is still set.
+ *                      Adds 18 bytes.
+ *
+ *  ENTRY_WATCHDOG      Activate the bootloader after a watchdog reset. This can be used
+ *                      to enter the bootloader from the user program.
+ *                      Adds 22 bytes.
+ *
+ *  ENTRY_EXT_RESET     Activate the bootloader after an external reset was issued by
+ *                      pulling the reset pin low. It may be necessary to add an external
+ *                      pull-up resistor to the reset pin if this entry method appears to
+ *                      behave unreliably.
+ *                      Adds 24 bytes.
+ *
+ *  ENTRY_JUMPER        Activate the bootloader when a specific pin is pulled low by an
+ *                      external jumper.
+ *                      Adds 34 bytes.
+ *
+ *       JUMPER_PIN     Pin the jumper is connected to. (e.g. PB0)
+ *       JUMPER_PORT    Port out register for the jumper (e.g. PORTB)
+ *       JUMPER_DDR     Port data direction register for the jumper (e.g. DDRB)
+ *       JUMPER_INP     Port input register for the jumper (e.g. PINB)
+ *
+ *  ENTRY_D_MINUS_PULLUP_ACTIVATED
+ *                      Activate the bootloader if the D- pin is high, i.e. a pullup resistor
+ *                      is attached and powered. Useful if the pullup is powered by USB V+
+ *                      and NOT by ATtiny VCC to save power.
+ *
+ */
+
+#define JUMPER_PIN    PB0
+#define JUMPER_PORT   PORTB
+#define JUMPER_DDR    DDRB
+#define JUMPER_INP    PINB
+
+// These definitions are only required for the #if #elif's below and the USB configuration reply.
+#define ENTRY_ALWAYS    0
+#define ENTRY_WATCHDOG  1
+#define ENTRY_EXT_RESET 2
+#define ENTRY_JUMPER    3
+#define ENTRY_POWER_ON  4
+// some useful combinations with ENTRY_D_MINUS_PULLUP_ACTIVATED
+#define ENTRY_D_MINUS_PULLUP_ACTIVATED_AND_ENTRY_POWER_ON  5
+#define ENTRY_D_MINUS_PULLUP_ACTIVATED_AND_ENTRY_EXT_RESET 6
+
+#define ENTRYMODE ENTRY_ALWAYS
+
+#if ENTRYMODE==ENTRY_ALWAYS
+  #define bootLoaderInit()
+  #define bootLoaderExit()
+  #define bootLoaderStartCondition() 1
+#elif ENTRYMODE==ENTRY_WATCHDOG
+  #define bootLoaderInit()
+  #define bootLoaderExit()
+  #define bootLoaderStartCondition() (MCUSR & _BV(WDRF))
+#elif ENTRYMODE==ENTRY_EXT_RESET
+  #define bootLoaderInit()
+  #define bootLoaderExit()
+// On my ATtiny85 I have always 0x03 EXTRF | PORF after power on.
+// After reset only EXTRF is NEWLY set.
+// So we must reset at least PORF flag ALWAYS after checking for this entry condition,
+// otherwise entry condition will NEVER be true if application does not reset PORF.
+  #define bootLoaderStartCondition() (MCUSR == _BV(EXTRF)) // Adds 18 bytes
+#elif ENTRYMODE==ENTRY_JUMPER
+  // Enable pull up on jumper pin and delay to stabilize input
+  // delay can be omitted to save memory, if external capacitance at the jumper pin is low
+  #define bootLoaderInit()   {JUMPER_DDR &= ~_BV(JUMPER_PIN); JUMPER_PORT |= _BV(JUMPER_PIN); _delay_ms(1);}
+  #define bootLoaderExit()   {JUMPER_PORT &= ~_BV(JUMPER_PIN);}
+  #define bootLoaderStartCondition() (!(JUMPER_INP & _BV(JUMPER_PIN)))
+#elif ENTRYMODE==ENTRY_POWER_ON
+  #define bootLoaderInit()
+  #define bootLoaderExit()
+  #define bootLoaderStartCondition() (MCUSR & _BV(PORF))
+#elif ENTRYMODE==ENTRY_D_MINUS_PULLUP_ACTIVATED_AND_ENTRY_POWER_ON
+  #define bootLoaderInit()
+  #define bootLoaderExit()
+  #define bootLoaderStartCondition()  ((USBIN & USBIDLE) && (MCUSR & _BV(PORF))) // Adds 22 bytes
+#elif ENTRYMODE==ENTRY_D_MINUS_PULLUP_ACTIVATED_AND_ENTRY_EXT_RESET
+  #define bootLoaderInit()
+  #define bootLoaderExit()
+  #define bootLoaderStartCondition() ((USBIN & USBIDLE) && (MCUSR == _BV(EXTRF))) // Adds 22 bytes
+#else
+   #error "No valid entry mode defined"
+#endif
+
+/*
+ *  Define MCUSR handling here.
+ *
+ *  Default is to clear MCUSR only if the bootloader is entered.
+ *
+ *  SAVE_MCUSR  The content of the MCUSR register is stored in GPIOR0 register
+ *              and the MCUSR register is cleared, even if the bootloader was not entered.
+ *              The latter is required to prepare for a correct entry condition
+ *              at the next call of the bootloader.
+ *              Adds 6 bytes.
+ *
+ *              The MCUSR content can be accessed by user program with:
+ *              "if (MCUSR != 0) tMCUSRStored = MCUSR; else tMCUSRStored = GPIOR0;"
+ *              The first "if" covers the default bootloader configuration.
+ */
+
+#define SAVE_MCUSR
+
+/*
+ * Define bootloader timeout value.
+ *
+ *  The bootloader will only time out if a user program was loaded.
+ *
+ *  FAST_EXIT_NO_USB_MS        The bootloader will exit after this delay if no USB is connected after the initial 300 ms disconnect and connect.
+ *                             Set to < 120 to disable.
+ *                             Adds 8 bytes.
+ *                             (This will wait for FAST_EXIT_NO_USB_MS milliseconds for an USB SE0 reset from the host, otherwise exit)
+ *
+ *  AUTO_EXIT_MS               The bootloader will exit after this delay if no USB communication from the host tool was received.
+ *                             Set to 0 to disable -> never leave the bootloader except on receiving an exit command by USB.
+ *
+ *  All values are approx. in milliseconds
+ */
+
+// I observed 2 resets. First is 100 ms after initial connecting to USB lasting 65 ms and the second 90 ms later and also 65 ms.
+// On my old HP laptop I have different timing: First reset is 220 ms after initial connecting to USB lasting 300 ms and the second is missing.
+#define FAST_EXIT_NO_USB_MS       0 // Values below 120 are ignored. Effective timeout is 300 + FAST_EXIT_NO_USB_MS.
+#define AUTO_EXIT_MS           6000
+
+/* ----------------------- Optional Timeout Config ------------------------ */
+
+/*
+ *  Defines the setting of the RC-oscillator calibration after quitting the bootloader. (OSCCAL)
+ *
+ *  OSCCAL_RESTORE_DEFAULT    Set this to '1' to revert to OSCCAL factory calibration after bootloader exit.
+ *                            This is 8 MHz +/-2% on most devices for 16 MHz on the ATtiny 85 with activated PLL.
+ *                            Adds ~14 bytes.
+ *
+ *  OSCCAL_SAVE_CALIB         Set this to '1' to save the OSCCAL calibration during program upload in FLASH.
+ *                            This value will be reloaded after reset and will also be used for the user
+ *                            program unless "OSCCAL_RESTORE_DEFAULT" is active. This allows calibrate the internal
+ *                            RC oscillator to the F_CPU target frequency +/-1% from the USB timing. Please note
+ *                            that this is only true if the ambient temperature does not change.
+ *                            Adds ~38 bytes.
+ *
+ *  OSCCAL_HAVE_XTAL          Set this to '1' if you have an external crystal oscillator. In this case no attempt
+ *                            will be made to calibrate the oscillator. You should deactivate both options above
+ *                            if you use this to avoid redundant code.
+ *
+ *  OSCCAL_SLOW_PROGRAMMING   Setting this to '1' will set OSCCAL back to the factory calibration during programming to make
+ *                            sure correct timing is used for the flash writes. This is needed if the micronucleus clock
+ *                            speed significantly deviated from the default clock. E.g. 12 Mhz on ATtiny841 vs. 8Mhz default.
+ *
+ *  If both options are selected, OSCCAL_RESTORE_DEFAULT takes precedence.
+ *
+ *  If no option is selected, OSCCAL will be left untouched and stays at either factory calibration or F_CPU depending
+ *  on whether the bootloader was activated. This will take the least memory. You can use this if your program
+ *  comes with its own OSCCAL calibration or an external clock source is used.
+ */
+
+#define OSCCAL_RESTORE_DEFAULT 0
+#define OSCCAL_SAVE_CALIB 1
+#define OSCCAL_HAVE_XTAL 0
+
+/*
+ *  Defines handling of an indicator LED while the bootloader is active.
+ *
+ *  LED_MODE                  Define behavior of attached LED or suppress LED code.
+ *
+ *          NONE              Do not generate LED code (gains 18 bytes).
+ *          ACTIVE_HIGH       LED is on when output pin is high. This will toggle between 1 and 0.
+ *          ACTIVE_LOW        LED is on when output pin is low.  This will toggle between Z and 0. + 2 bytes
+ *
+ *  LED_DDR,LED_PORT,LED_PIN  Where is your LED connected?
+ *
+ */
+
+#define NONE        0
+#define ACTIVE_HIGH 1
+#define ACTIVE_LOW  2
+
+#define LED_MODE    NONE
+
+#define LED_DDR     DDRB
+#define LED_PORT    PORTB
+#define LED_PIN     PB1
+
+/*
+ *  This is the implementation of the LED code. Change the configuration above unless you want to
+ *  change the led behavior
+ *
+ *  LED_INIT                  Called once after bootloader entry
+ *  LED_EXIT                  Called once during bootloader exit
+ *  LED_MACRO                 Called in the main loop with the idle counter as parameter.
+ *                            Use to define pattern.
+ */
+
+#if LED_MODE==ACTIVE_HIGH
+  #define LED_INIT(x)   LED_DDR |= _BV(LED_PIN);
+  #define LED_EXIT(x)   LED_PORT &= ~_BV(LED_PIN);
+  #define LED_MACRO(x)  if ( x & 0x4c ) {LED_PORT &= ~_BV(LED_PIN);} else {LED_PORT |= _BV(LED_PIN);}
+#elif LED_MODE==ACTIVE_LOW
+  #define LED_INIT(x)   LED_PORT &= ~_BV(LED_PIN);
+  #define LED_EXIT(x)   LED_DDR &= ~_BV(LED_PIN);
+  #define LED_MACRO(x)  if ( x & 0x4c ) {LED_DDR &= ~_BV(LED_PIN);} else {LED_DDR |= _BV(LED_PIN);}
+#elif LED_MODE==NONE
+  #define LED_INIT(x)
+  #define LED_EXIT(x)
+  #define LED_MACRO(x)
+#endif
+
+/* ----------------------- USB descriptors ------------------------ */
+#define WINUSB
+
+
+#endif /* __bootloader_h_included__ */

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -1,6 +1,7 @@
 /*
  * Project: Micronucleus -  v2.5
  *
+ * WinUSB                        (c) 2018 Marius Greuel
  * Micronucleus V2.5             (c) 2020 Armin Joachimsmeyer armin.joachimsmeyer@gmail.com
  * Micronucleus V2.04            (c) 2016 Tim Bo"scke - cpldcpu@gmail.com
  * Micronucleus V2.3             (c) 2016 Tim Bo"scke - cpldcpu@gmail.com
@@ -83,6 +84,32 @@
 #warning "Values below 120 ms are not possible for FAST_EXIT_NO_USB_MS"
 #endif
 
+typedef struct {
+  uint32_t dwLength;
+  uint16_t bcdVersion;
+  uint16_t wIndex;
+  uint8_t bCount;
+  uint8_t reserved[7];
+} ExtCompatHeader_t;
+
+typedef struct {
+  ExtCompatHeader_t header;
+  uint8_t bFirstInterfaceNumber;
+  uint8_t reserved1;
+  char compatibleID[8];
+  char subCompatibleID[8];
+  uint8_t reserved2[6];
+} ExtCompatDescriptor_t;
+
+PROGMEM const ExtCompatDescriptor_t msExtCompatDescriptor =
+{
+  { sizeof(ExtCompatDescriptor_t), 0x0100, 0x0004, 1 },
+  0,
+  1,
+  "WINUSB",
+  ""
+};
+
 // Device configuration reply
 // Length: 6 bytes
 //   Byte 0:  User program memory size, high byte
@@ -150,6 +177,7 @@ enum {
     cmd_erase_application = 2,
     cmd_write_data = 3,
     cmd_exit = 4,
+    cmd_get_ms_descriptor = GET_MS_DESCRIPTOR,
     cmd_write_page = 64  // internal commands start at 64
 };
 register uint8_t command asm("r3");  // bind command to r3
@@ -307,6 +335,11 @@ static uint8_t usbFunctionSetup(uint8_t data[8]) {
         writeWordToPageBuffer(rq->wIndex.word);
         if ((currentAddress.b[0] % SPM_PAGESIZE) == 0) {
             command = cmd_write_page; // ask main loop to write our page
+        }
+    } else if (rq->bRequest == cmd_get_ms_descriptor) {
+        if (rq->wIndex.word == 0x0004) {
+            usbMsgPtr = (usbMsgPtr_t)&msExtCompatDescriptor;
+            return sizeof(msExtCompatDescriptor);
         }
     } else {
         // Handle cmd_erase_application and cmd_exit

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -336,11 +336,13 @@ static uint8_t usbFunctionSetup(uint8_t data[8]) {
         if ((currentAddress.b[0] % SPM_PAGESIZE) == 0) {
             command = cmd_write_page; // ask main loop to write our page
         }
+#ifdef WINUSB
     } else if (rq->bRequest == cmd_get_ms_descriptor) {
         if (rq->wIndex.word == 0x0004) {
             usbMsgPtr = (usbMsgPtr_t)&msExtCompatDescriptor;
             return sizeof(msExtCompatDescriptor);
         }
+#endif /* WINUSB */
     } else {
         // Handle cmd_erase_application and cmd_exit
         command = rq->bRequest & 0x3f;

--- a/firmware/usbconfig.h
+++ b/firmware/usbconfig.h
@@ -99,8 +99,8 @@
  * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
  * details.
  */
-//#define USB_CFG_DEVICE_NAME 0x00B5,'B'
-//#define USB_CFG_DEVICE_NAME_LEN 2
+#define USB_CFG_DEVICE_NAME 'M', 'i', 'c', 'r', 'o', 'n', 'u', 'c', 'l', 'e', 'u', 's', ' ', 'B', 'o', 'o', 't', 'l', 'o', 'a', 'd', 'e', 'r'
+#define USB_CFG_DEVICE_NAME_LEN 23
 /* Same as above for the device name. If you don't want a device name, undefine
  * the macros. See the file USB-IDs-for-free.txt before you assign a name if
  * you use a shared VID/PID.
@@ -114,14 +114,17 @@
  * to fine tune control over USB descriptors such as the string descriptor
  * for the serial number.
  */
+#define USB_CFG_OS_STRING 'M', 'S', 'F', 'T', '1', '0', '0', GET_MS_DESCRIPTOR
+#define USB_CFG_OS_STRING_LEN 8
+#define GET_MS_DESCRIPTOR 5 /* command for requesting the OS feature descriptor */
+ /* OS String Descriptor for Windows WinUSB driver.
+ */
 #define USB_CFG_DEVICE_CLASS        0xff    /* set to 0 if deferred to interface */
 #define USB_CFG_DEVICE_SUBCLASS     0
-//#define USB_CFG_DEVICE_CLASS    0xFE /* application specific */
-//#define USB_CFG_DEVICE_SUBCLASS 0x01 /* device firmware upgrade */
 /* See USB specification if you want to conform to an existing device class.
  * Class 0xff is "vendor specific".
  */
-#define USB_CFG_INTERFACE_CLASS     0   /* define class here if not at device level */
+#define USB_CFG_INTERFACE_CLASS     0xff   /* define class here if not at device level */
 #define USB_CFG_INTERFACE_SUBCLASS  0
 #define USB_CFG_INTERFACE_PROTOCOL  0
 /* See USB specification if you want to conform to an existing device class or
@@ -172,11 +175,12 @@
 
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 1
+#define USB_CFG_DESCR_PROPS_STRINGS                 0
 #define USB_CFG_DESCR_PROPS_STRING_0                0
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    0
+#define USB_CFG_DESCR_PROPS_STRING_OS_STRING        0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 #endif /* __usbconfig_h_included__ */

--- a/firmware/usbconfig.h
+++ b/firmware/usbconfig.h
@@ -99,8 +99,8 @@
  * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
  * details.
  */
-#define USB_CFG_DEVICE_NAME 'M', 'i', 'c', 'r', 'o', 'n', 'u', 'c', 'l', 'e', 'u', 's', ' ', 'B', 'o', 'o', 't', 'l', 'o', 'a', 'd', 'e', 'r'
-#define USB_CFG_DEVICE_NAME_LEN 23
+//#define USB_CFG_DEVICE_NAME 'M', 'i', 'c', 'r', 'o', 'n', 'u', 'c', 'l', 'e', 'u', 's', ' ', 'B', 'o', 'o', 't', 'l', 'o', 'a', 'd', 'e', 'r'
+//#define USB_CFG_DEVICE_NAME_LEN 23
 /* Same as above for the device name. If you don't want a device name, undefine
  * the macros. See the file USB-IDs-for-free.txt before you assign a name if
  * you use a shared VID/PID.

--- a/firmware/usbconfig.h
+++ b/firmware/usbconfig.h
@@ -175,7 +175,11 @@
 
 #define USB_CFG_DESCR_PROPS_DEVICE                  0
 #define USB_CFG_DESCR_PROPS_CONFIGURATION           0
-#define USB_CFG_DESCR_PROPS_STRINGS                 0
+#ifdef WINUSB
+    #define USB_CFG_DESCR_PROPS_STRINGS                 0
+#else
+    #define USB_CFG_DESCR_PROPS_STRINGS                 1
+#endif /* WINUSB */
 #define USB_CFG_DESCR_PROPS_STRING_0                0
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR           0
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT          0

--- a/firmware/usbdrv/usbdrv.c
+++ b/firmware/usbdrv/usbdrv.c
@@ -101,6 +101,15 @@ PROGMEM const int usbDescriptorStringSerialNumber[] = {
 };
 #endif
 
+#if USB_CFG_DESCR_PROPS_STRING_OS_STRING == 0 && USB_CFG_OS_STRING_LEN
+#undef USB_CFG_DESCR_PROPS_STRING_OS_STRING
+#define USB_CFG_DESCR_PROPS_STRING_OS_STRING sizeof(usbDescriptorStringOsString)
+PROGMEM const int usbDescriptorStringOsString[] = {
+    USB_STRING_DESCRIPTOR_HEADER(USB_CFG_OS_STRING_LEN),
+    USB_CFG_OS_STRING
+};
+#endif
+
 #endif  /* USB_CFG_DESCR_PROPS_STRINGS == 0 */
 
 /* --------------------------- Device Descriptor --------------------------- */
@@ -108,23 +117,24 @@ PROGMEM const int usbDescriptorStringSerialNumber[] = {
 #if USB_CFG_DESCR_PROPS_DEVICE == 0
 #undef USB_CFG_DESCR_PROPS_DEVICE
 #define USB_CFG_DESCR_PROPS_DEVICE  sizeof(usbDescriptorDevice)
-PROGMEM const char usbDescriptorDevice[] = { /* USB device descriptor */
-18, /* sizeof(usbDescriptorDevice): length of descriptor in bytes */
-USBDESCR_DEVICE, /* descriptor type */
-0x10, 0x01, /* USB version supported */
-USB_CFG_DEVICE_CLASS,
-USB_CFG_DEVICE_SUBCLASS, 0, /* protocol */
-8, /* max packet size */
-/* the following two casts affect the first byte of the constant only, but
- * that's sufficient to avoid a warning with the default values.
- */
-(char) USB_CFG_VENDOR_ID,/* 2 bytes */
-(char) USB_CFG_DEVICE_ID,/* 2 bytes */
-USB_CFG_DEVICE_VERSION, /* 2 bytes */
-USB_CFG_DESCR_PROPS_STRING_VENDOR != 0 ? 1 : 0, /* manufacturer string index */
-USB_CFG_DESCR_PROPS_STRING_PRODUCT != 0 ? 2 : 0, /* product string index */
-USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER != 0 ? 3 : 0, /* serial number string index */
-1, /* number of configurations */
+    PROGMEM const char usbDescriptorDevice[] = { /* USB device descriptor */
+    18, /* sizeof(usbDescriptorDevice): length of descriptor in bytes */
+    USBDESCR_DEVICE, /* descriptor type */
+    0x00, 0x02,             /* USB version supported */
+    USB_CFG_DEVICE_CLASS,
+    USB_CFG_DEVICE_SUBCLASS,
+    0, /* protocol */
+    8, /* max packet size */
+    /* the following two casts affect the first byte of the constant only, but
+     * that's sufficient to avoid a warning with the default values.
+     */
+    (char) USB_CFG_VENDOR_ID,/* 2 bytes */
+    (char) USB_CFG_DEVICE_ID,/* 2 bytes */
+    USB_CFG_DEVICE_VERSION, /* 2 bytes */
+    USB_CFG_DESCR_PROPS_STRING_VENDOR != 0 ? 1 : 0, /* manufacturer string index */
+    USB_CFG_DESCR_PROPS_STRING_PRODUCT != 0 ? 2 : 0, /* product string index */
+    USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER != 0 ? 3 : 0, /* serial number string index */
+    1, /* number of configurations */
 };
 #endif
 
@@ -198,6 +208,8 @@ static inline usbMsgLen_t usbDriverDescriptor(usbRequest_t *rq) {
                 GET_DESCRIPTOR(USB_CFG_DESCR_PROPS_STRING_PRODUCT, usbDescriptorStringDevice)
             } else if (_cmd == (3)) {
                 GET_DESCRIPTOR(USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER, usbDescriptorStringSerialNumber)
+            } else if (_cmd == (0xee)) {
+                GET_DESCRIPTOR(USB_CFG_DESCR_PROPS_STRING_OS_STRING, usbDescriptorStringOsString)
             }
         }
     }

--- a/firmware/usbdrv/usbdrv.c
+++ b/firmware/usbdrv/usbdrv.c
@@ -208,8 +208,10 @@ static inline usbMsgLen_t usbDriverDescriptor(usbRequest_t *rq) {
                 GET_DESCRIPTOR(USB_CFG_DESCR_PROPS_STRING_PRODUCT, usbDescriptorStringDevice)
             } else if (_cmd == (3)) {
                 GET_DESCRIPTOR(USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER, usbDescriptorStringSerialNumber)
+#ifdef WINUSB
             } else if (_cmd == (0xee)) {
                 GET_DESCRIPTOR(USB_CFG_DESCR_PROPS_STRING_OS_STRING, usbDescriptorStringOsString)
+#endif /* WINUSB */
             }
         }
     }


### PR DESCRIPTION
As mentioned in #287 a feature descriptor for WinUSB would be very helpful, as this allows webbrowsers to use Micronucleus devices without requiring any drivers. Luckily @mariusgreuel already has a fork of with this descriptor. This PR is just a cherry-pick of ff5d3f51d793de2b2515aa04bc5349687aca061f.

Unfortunately this feature adds a lot of bytes (about two pages for me!), this should be guarded behind `#define` — that's why I marked this PR as a draft. 